### PR TITLE
Use docker-py plugin for testing and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ before_install:
   - cd ..
 
   # pull and start up freeswitch container bound to 'lo'
-  - docker pull safarov/freeswitch
-  - docker run -d --net=host -v $TRAVIS_BUILD_DIR/conf/ci-minimal/:/etc/freeswitch safarov/freeswitch
-  - docker ps -a
+  # - docker pull safarov/freeswitch
+  # - docker run -d --net=host -v $TRAVIS_BUILD_DIR/conf/ci-minimal/:/etc/freeswitch safarov/freeswitch
+  # - docker ps -a
 
 install:
   # - pip install -U tox
@@ -34,4 +34,4 @@ install:
 
 # NOTE: no support for pandas/pytables yet
 script:
-  - pytest --fshost=127.0.0.1 tests/
+  - pytest --use_docker tests/ -sv

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ install:
 
 # NOTE: no support for pandas/pytables yet
 script:
-  - pytest --use_docker tests/ -sv
+  - pytest --use-docker tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,25 @@ python:
     # - pypy
     - nightly
 
-addons:
-  apt:
-    packages:
-      - swig
 
 before_install:
-  # build and install SIPp
-  - git clone https://github.com/SIPp/sipp.git
-  - cd sipp
-  - ./build.sh
-  - export PATH="$PWD:$PATH"
-  - cd ..
+    # build and install latest SWIG
+    - git clone https://github.com/swig/swig.git
+    - cd swig
+    - git checkout rel-3.0.12
+    - ./autogen.sh
+    - ./configure --prefix=$HOME/swig
+    - make
+    - make install
+    - export PATH="$HOME/swig/bin/:$PATH"
+    - cd ..
+
+    # build and install SIPp
+    - git clone https://github.com/SIPp/sipp.git
+    - cd sipp
+    - ./build.sh
+    - export PATH="$PWD:$PATH"
+    - cd ..
 
   # pull and start up freeswitch container bound to 'lo'
   # - docker pull safarov/freeswitch
@@ -30,6 +37,7 @@ before_install:
 
 install:
   # - pip install -U tox
+  - cd $TRAVIS_BUILD_DIR
   - pip install . -r requirements-test.txt
 
 # NOTE: no support for pandas/pytables yet

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 
 install:
   # - pip install -U tox
-  - pip install .  -r requirements-test.txt
+  - pip install . -r requirements-test.txt
 
 # NOTE: no support for pandas/pytables yet
 script:

--- a/conf/ci-minimal/autoload_configs/event_socket.conf.xml
+++ b/conf/ci-minimal/autoload_configs/event_socket.conf.xml
@@ -1,8 +1,9 @@
 <configuration name="event_socket.conf" description="Socket Client">
   <settings>
     <param name="nat-map" value="false"/>
-    <param name="listen-ip" value="127.0.0.1"/>
+    <param name="listen-ip" value="0.0.0.0"/>
     <param name="listen-port" value="8021"/>
     <param name="password" value="ClueCon"/>
+    <param name="apply-inbound-acl" value="any_v4.auto"/>
   </settings>
 </configuration>

--- a/conf/ci-minimal/vars.xml
+++ b/conf/ci-minimal/vars.xml
@@ -1,10 +1,5 @@
 <include>
   <X-PRE-PROCESS cmd="set" data="global_codec_prefs=PCMU,PCMA"/>
-
-  <!-- NOTE: CHANGE THIS BEFORE USE -->
-  <X-PRE-PROCESS cmd="set" data="xml_rpc_password=worksnot"/>
-
   <X-PRE-PROCESS cmd="set" data="internal_sip_port=5060"/>
   <X-PRE-PROCESS cmd="set" data="external_sip_port=5080"/>
-  <X-PRE-PROCESS cmd="set" data="local_ip_v4=127.0.0.1"/>
 </include>

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,6 @@ pdbpp
 
 # pysipp for call tracking testing
 -e git+git://github.com/SIPp/pysipp.git#egg=pysipp
+
+# pytest-dockerctl for container mgmt
+-e git+git://github.com/tgoodlet/pytest-dockerctl.git#egg=pytest-dockerctl


### PR DESCRIPTION
Manage docker from within the test suite enabling the run of the cluster tests as well as breaking ground for eventual elasticity testing as it pertains to dynamically scaling `switchy` routing services.

This also allows a developer to run the full tests suite as long as `docker` is installed without having to spin up a container(s) manually.

@vodik @moises-silva ping!